### PR TITLE
feat: add ADDITIONAL_LIBS environment variable

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -121,6 +121,7 @@ export default {
             new HtmlWebPackPlugin({
                 inject: false,
                 template: path.resolve(paths.ownPath, "lib", "index.ejs"),
+                additionalLibs: process.env.ADDITIONAL_LIBS
             }),
 
         new ForkTsCheckerWebpackPlugin({

--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -29,6 +29,7 @@
         <script>
             function iframeLoaded(event) {
                 const webpackFiles = <%= JSON.stringify(htmlWebpackPlugin.files) %>;
+                const additionalLibs = <%= (htmlWebpackPlugin.options.additionalLibs ?? "[]") %>;
                 const iframeDocument = event.target.contentDocument;
                 const iframeWindow = event.target.contentWindow;
 
@@ -79,7 +80,8 @@
                     require([
                         "@vertigis/web-libraries!/common",
                         "@vertigis/web-libraries!/web",
-                        webpackFiles.js[0]
+                        webpackFiles.js[0],
+                        ...additionalLibs
                     ], (
                         ...libs
                     ) => {


### PR DESCRIPTION
Adds a ADDITIONAL_LIBS environment variable that allows you to load additional Studio Web SDK libraries. So far when developing a library with the Studio Web SDK, the local dev server only allowed working with the library you were developing. With help of the ADDITIONAL_LIBS environment variable you can configure your Studio Web SDK project to inject other external Studio Web SDK libraries. 

To use this you might add something like this to your package.json (or use cross-env):

    "start": "vertigis-web-sdk start",
    "start:app-with-additional-lib": "set ADDITIONAL_LIBS=['https://yourwebsite.com/yourlib.js']&& npm run start"