### PR TITLE
chore: Replace outdated Geocortex URLs with VertiGIS URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VertiGIS Studio Web SDK
 
-![CI/CD](https://github.com/geocortex/vertigis-web-sdk/workflows/CI/CD/badge.svg)
+![CI/CD](https://github.com/vertigis/vertigis-web-sdk/workflows/CI/CD/badge.svg)
 
 This SDK makes it easy to create custom libraries for [VertiGIS Studio Web](https://vertigisstudio.com/products/vertigis-studio-web/).
 
@@ -39,11 +39,11 @@ Builds the library for production to the `build` folder. It optimizes the build 
 
 Your custom library is now ready to be deployed!
 
-See the [section about deployment](https://developers.geocortex.com/docs/web/sdk-deployment/) in the [Developer Center](https://developers.geocortex.com/docs/web/overview/) for more information.
+See the [section about deployment](https://developers.vertigis.com/docs/web/sdk-deployment/) in the [Developer Center](https://developers.vertigis.com/docs/web/overview/) for more information.
 
 ## Documentation
 
-Find [further documentation on the SDK](https://developers.geocortex.com/docs/web/sdk-overview/) on the [VertiGIS Studio Developer Center](https://developers.geocortex.com/docs/web/overview/)
+Find [further documentation on the SDK](https://developers.vertigis.com/docs/web/sdk-overview/) on the [VertiGIS Studio Developer Center](https://developers.vertigis.com/docs/web/overview/)
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
                 "typescript": "5.3.3"
             },
             "engines": {
-                "node": ">=16",
+                "node": ">=18",
                 "npm": ">=8"
             }
         },

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
     "description": "The SDK for extending VertiGIS Studio Web",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/geocortex/vertigis-web-sdk.git"
+        "url": "git+https://github.com/vertigis/vertigis-web-sdk.git"
     },
     "author": "VertiGIS Ltd. <eric.parsons@vertigis.com>",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/geocortex/vertigis-web-sdk/issues"
+        "url": "https://github.com/vertigis/vertigis-web-sdk/issues"
     },
-    "homepage": "https://github.com/geocortex/vertigis-web-sdk#readme",
+    "homepage": "https://github.com/vertigis/vertigis-web-sdk#readme",
     "files": [
         "bin",
         "config",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -61,7 +61,7 @@ const build = () => {
                 );
                 console.log(
                     `You can learn more about deploying your custom code at ${chalk.cyan(
-                        "https://developers.geocortex.com/docs/web/overview/"
+                        "https://developers.vertigis.com/docs/web/overview/"
                     )}`
                 );
             }

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -145,7 +145,7 @@ const printSuccess = () => {
     console.log(chalk.cyan(`  cd ${directoryName}`));
     console.log(chalk.cyan("  npm start\n"));
     console.log(
-        "You can learn more by visiting https://developers.geocortex.com/docs/web/sdk-overview/"
+        "You can learn more by visiting https://developers.vertigis.com/docs/web/sdk-overview/"
     );
 };
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,4 +1,4 @@
-This project was bootstrapped with the [VertiGIS Studio Web SDK](https://github.com/geocortex/vertigis-web-sdk).
+This project was bootstrapped with the [VertiGIS Studio Web SDK](https://github.com/vertigis/vertigis-web-sdk).
 
 ## Available Scripts
 
@@ -16,8 +16,8 @@ Builds the library for production to the `build` folder. It optimizes the build 
 
 Your custom library is now ready to be deployed!
 
-See the [section about deployment](https://developers.geocortex.com/docs/web/sdk-deployment/) in the [Developer Center](https://developers.geocortex.com/docs/web/overview/) for more information.
+See the [section about deployment](https://developers.vertigis.com/docs/web/sdk-deployment/) in the [Developer Center](https://developers.vertigis.com/docs/web/overview/) for more information.
 
 ## Learn More
 
-Find [further documentation on the SDK](https://developers.geocortex.com/docs/web/sdk-overview/) on the [VertiGIS Studio Developer Center](https://developers.geocortex.com/docs/web/overview/)
+Find [further documentation on the SDK](https://developers.vertigis.com/docs/web/sdk-overview/) on the [VertiGIS Studio Developer Center](https://developers.vertigis.com/docs/web/overview/)


### PR DESCRIPTION
This PR updates obsolete Geocortex URLs and replaces them with their VertiGIS equivalents. 

There is also a problem with releases on GitHub at the moment that is highly likely being caused by the redirect from the old GitHub org.