### PR TITLE
fix: broken urls in scripts, other misc items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.0.0-semantically-released",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "~7.0.1",
-                "@typescript-eslint/parser": "~7.0.1",
+                "@typescript-eslint/eslint-plugin": "~7.4.0",
+                "@typescript-eslint/parser": "~7.4.0",
                 "chalk": "~5.3.0",
                 "clean-webpack-plugin": "~4.0.0",
                 "css-loader": "~6.10.0",
@@ -45,7 +45,7 @@
                 "p-retry": "6.2.0",
                 "playwright-chromium": "1.41.2",
                 "prettier": "3.2.5",
-                "semantic-release": "23.0.2",
+                "semantic-release": "23.0.6",
                 "simple-git-hooks": "2.9.0",
                 "typescript": "5.3.3"
             },
@@ -2190,87 +2190,87 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.0.1.tgz",
+            "integrity": "sha512-RTmWsLfig8SBoiSdgvCht4BXl1CHU89Co5xiQ5JF19my/sIRDFCQ1RPrmK0exgqUZuNm39C/bV8+/83+MJEjGg==",
             "dev": true,
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
-            "integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.0.1.tgz",
+            "integrity": "sha512-MIpPQXu8Y8GjHwXM81JLveiV+DHJZtLMcB5nKekBGOl3iAtk0HT3i12Xl8Biybu+bCS1+k4qbuKEq5d0RxNRnQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.0.0",
-                "@octokit/request": "^8.0.2",
-                "@octokit/request-error": "^5.0.0",
+                "@octokit/auth-token": "^5.0.0",
+                "@octokit/graphql": "^8.0.0",
+                "@octokit/request": "^9.0.0",
+                "@octokit/request-error": "^6.0.1",
                 "@octokit/types": "^12.0.0",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
+                "before-after-hook": "^3.0.2",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
-            "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.0.0.tgz",
+            "integrity": "sha512-emBcNDxBdC1y3+knJonS5zhUB/CG6TihubxM2U1/pG/Z1y3a4oV0Gzz3lmkCvWWQI6h3tqBAX9MgCBFp+M68Jw==",
             "dev": true,
             "dependencies": {
                 "@octokit/types": "^12.0.0",
-                "universal-user-agent": "^6.0.0"
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
-            "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.0.1.tgz",
+            "integrity": "sha512-lLDb6LhC1gBj2CxEDa5Xk10+H/boonhs+3Mi6jpRyetskDKNHe6crMeKmUE2efoLofMP8ruannLlCUgpTFmVzQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/request": "^8.0.1",
+                "@octokit/request": "^9.0.0",
                 "@octokit/types": "^12.0.0",
-                "universal-user-agent": "^6.0.0"
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.1.0.tgz",
-            "integrity": "sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
             "dev": true
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "9.1.5",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.5.tgz",
-            "integrity": "sha512-WKTQXxK+bu49qzwv4qKbMMRXej1DU2gq017euWyKVudA6MldaSSQuxtz+vGbhxV4CjxpUxjZu6rM2wfc1FiWVg==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-10.0.0.tgz",
+            "integrity": "sha512-G1Z67qOiFneKDJyMafHQkWnKm1kU3FfbRZLzxgsFg4dOa3pRNdABbdk+xo/oev6P88lnbt7GKdBNB6dJZuPphA==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^12.4.0"
+                "@octokit/types": "^12.6.0"
             },
             "engines": {
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=5"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/plugin-retry": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
-            "integrity": "sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.0.3.tgz",
+            "integrity": "sha512-T9l5Z7XnDZ7dkyNmhJPSUq0YjbqUT/xn4yQbhcSuv4WGC/LqM73/mKwkl68VDPoLw20e8oz4L7qQopWt9v6sow==",
             "dev": true,
             "dependencies": {
-                "@octokit/request-error": "^5.0.0",
+                "@octokit/request-error": "^6.0.0",
                 "@octokit/types": "^12.0.0",
                 "bottleneck": "^2.15.3"
             },
@@ -2278,61 +2278,59 @@
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=5"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/plugin-throttling": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.1.3.tgz",
-            "integrity": "sha512-pfyqaqpc0EXh5Cn4HX9lWYsZ4gGbjnSmUILeu4u2gnuM50K/wIk9s1Pxt3lVeVwekmITgN/nJdoh43Ka+vye8A==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.0.3.tgz",
+            "integrity": "sha512-DReKamrLBJOzld73dmmxV2H137QKJfsxszAczEZXeAJQ/Po6bzQacKajPdodA6T1jfmP9+waImus+d/R2j+R7Q==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^12.2.0",
+                "@octokit/types": "^12.6.0",
                 "bottleneck": "^2.15.3"
             },
             "engines": {
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": "^5.0.0"
+                "@octokit/core": "^6.0.0"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
-            "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.0.1.tgz",
+            "integrity": "sha512-kL+cAcbSl3dctYLuJmLfx6Iku2MXXy0jszhaEIjQNaCp4zjHXrhVAHeuaRdNvJjW9qjl3u1MJ72+OuBP0YW/pg==",
             "dev": true,
             "dependencies": {
-                "@octokit/endpoint": "^9.0.0",
-                "@octokit/request-error": "^5.0.0",
+                "@octokit/endpoint": "^10.0.0",
+                "@octokit/request-error": "^6.0.1",
                 "@octokit/types": "^12.0.0",
-                "universal-user-agent": "^6.0.0"
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-            "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.0.2.tgz",
+            "integrity": "sha512-WtRVpoHcNXs84+s9s/wqfHaxM68NGMg8Av7h59B50OVO0PwwMx+2GgQ/OliUd0iQBSNWgR6N8afi/KjSHbXHWw==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^12.0.0",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
+                "@octokit/types": "^12.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "12.4.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.4.0.tgz",
-            "integrity": "sha512-FLWs/AvZllw/AGVs+nJ+ELCDZZJk+kY0zMen118xhL2zD0s1etIUHm1odgjP7epxYU1ln7SZxEUWYop5bhsdgQ==",
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
             "dev": true,
             "dependencies": {
-                "@octokit/openapi-types": "^19.1.0"
+                "@octokit/openapi-types": "^20.0.0"
             }
         },
         "node_modules/@pnpm/config.env-replace": {
@@ -2387,9 +2385,9 @@
             }
         },
         "node_modules/@semantic-release/commit-analyzer": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.1.0.tgz",
-            "integrity": "sha512-cXNTbv3nXR2hlzHjAMgbuiQVtvWHTlwwISt60B+4NZv01y/QRY7p2HcJm8Eh2StzcTJoNnflvKjHH/cjFS7d5g==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
+            "integrity": "sha512-qG+md5gdes+xa8zP7lIo1fWE17zRdO8yMCaxh9lyL65TQleoSv8WHHOqRURfghTytUh+NpkSyBprQ5hrkxOKVQ==",
             "dev": true,
             "dependencies": {
                 "conventional-changelog-angular": "^7.0.0",
@@ -2401,7 +2399,7 @@
                 "micromatch": "^4.0.2"
             },
             "engines": {
-                "node": "^18.17 || >=20.6.1"
+                "node": ">=20.8.1"
             },
             "peerDependencies": {
                 "semantic-release": ">=20.1.0"
@@ -2417,15 +2415,15 @@
             }
         },
         "node_modules/@semantic-release/github": {
-            "version": "9.2.6",
-            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.6.tgz",
-            "integrity": "sha512-shi+Lrf6exeNZF+sBhK+P011LSbhmIAoUEgEY6SsxF8irJ+J2stwI5jkyDQ+4gzYyDImzV6LCKdYB9FXnQRWKA==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.0.2.tgz",
+            "integrity": "sha512-SP5ihhv/uQa8vPuWKmbJrrzfv8lRUkDFC6qwgaWoorrflN1DEW0IGCa9w/PxUp8Ad3dbvXZPmpXdGiP3eyTzhg==",
             "dev": true,
             "dependencies": {
-                "@octokit/core": "^5.0.0",
-                "@octokit/plugin-paginate-rest": "^9.0.0",
-                "@octokit/plugin-retry": "^6.0.0",
-                "@octokit/plugin-throttling": "^8.0.0",
+                "@octokit/core": "^6.0.0",
+                "@octokit/plugin-paginate-rest": "^10.0.0",
+                "@octokit/plugin-retry": "^7.0.0",
+                "@octokit/plugin-throttling": "^9.0.0",
                 "@semantic-release/error": "^4.0.0",
                 "aggregate-error": "^5.0.0",
                 "debug": "^4.3.4",
@@ -2433,14 +2431,14 @@
                 "globby": "^14.0.0",
                 "http-proxy-agent": "^7.0.0",
                 "https-proxy-agent": "^7.0.0",
-                "issue-parser": "^6.0.0",
+                "issue-parser": "^7.0.0",
                 "lodash-es": "^4.17.21",
                 "mime": "^4.0.0",
                 "p-filter": "^4.0.0",
                 "url-join": "^5.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20.8.1"
             },
             "peerDependencies": {
                 "semantic-release": ">=20.1.0"
@@ -2491,9 +2489,9 @@
             }
         },
         "node_modules/@semantic-release/npm": {
-            "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-11.0.2.tgz",
-            "integrity": "sha512-owtf3RjyPvRE63iUKZ5/xO4uqjRpVQDUB9+nnXj0xwfIeM9pRl+cG+zGDzdftR4m3f2s4Wyf3SexW+kF5DFtWA==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.0.tgz",
+            "integrity": "sha512-72TVYQCH9NvVsO/y13eF8vE4bNnfls518+4KcFwJUKi7AtA/ZXoNgSg9gTTfw5eMZMkiH0izUrpGXgZE/cSQhA==",
             "dev": true,
             "dependencies": {
                 "@semantic-release/error": "^4.0.0",
@@ -2503,7 +2501,7 @@
                 "lodash-es": "^4.17.21",
                 "nerf-dart": "^1.0.0",
                 "normalize-url": "^8.0.0",
-                "npm": "^10.0.0",
+                "npm": "^10.5.0",
                 "rc": "^1.2.8",
                 "read-pkg": "^9.0.0",
                 "registry-auth-token": "^5.0.0",
@@ -2511,16 +2509,16 @@
                 "tempy": "^3.0.0"
             },
             "engines": {
-                "node": "^18.17 || >=20"
+                "node": ">=20.8.1"
             },
             "peerDependencies": {
                 "semantic-release": ">=20.1.0"
             }
         },
         "node_modules/@semantic-release/release-notes-generator": {
-            "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.1.0.tgz",
-            "integrity": "sha512-g6M9AjUKAZUZnxaJZnouNBeDNTCUrJ5Ltj+VJ60gJeDaRRahcHsry9HW8yKrnKkKNkx5lbWiEP1FPMqVNQz8Kg==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-13.0.0.tgz",
+            "integrity": "sha512-LEeZWb340keMYuREMyxrODPXJJ0JOL8D/mCl74B4LdzbxhtXV2LrPN2QBEcGJrlQhoqLO0RhxQb6masHytKw+A==",
             "dev": true,
             "dependencies": {
                 "conventional-changelog-angular": "^7.0.0",
@@ -2535,7 +2533,7 @@
                 "read-pkg-up": "^11.0.0"
             },
             "engines": {
-                "node": "^18.17 || >=20.6.1"
+                "node": ">=20.8.1"
             },
             "peerDependencies": {
                 "semantic-release": ">=20.1.0"
@@ -2566,9 +2564,9 @@
             }
         },
         "node_modules/@sindresorhus/merge-streams": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.2.1.tgz",
-            "integrity": "sha512-255V7MMIKw6aQ43Wbqp9HZ+VHn6acddERTLiiLnlcPLU9PdTq9Aijl12oklAgUEblLWye+vHLzmqBx6f2TGcZw==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
             "dev": true,
             "engines": {
                 "node": ">=18"
@@ -2835,9 +2833,9 @@
             "dev": true
         },
         "node_modules/@types/semver": {
-            "version": "7.5.7",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
-            "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg=="
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
         },
         "node_modules/@types/send": {
             "version": "0.17.4",
@@ -2883,15 +2881,15 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.1.tgz",
-            "integrity": "sha512-OLvgeBv3vXlnnJGIAgCLYKjgMEU+wBGj07MQ/nxAaON+3mLzX7mJbhRYrVGiVvFiXtwFlkcBa/TtmglHy0UbzQ==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
+            "integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "7.0.1",
-                "@typescript-eslint/type-utils": "7.0.1",
-                "@typescript-eslint/utils": "7.0.1",
-                "@typescript-eslint/visitor-keys": "7.0.1",
+                "@typescript-eslint/scope-manager": "7.4.0",
+                "@typescript-eslint/type-utils": "7.4.0",
+                "@typescript-eslint/utils": "7.4.0",
+                "@typescript-eslint/visitor-keys": "7.4.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -2900,7 +2898,7 @@
                 "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2917,18 +2915,18 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.1.tgz",
-            "integrity": "sha512-8GcRRZNzaHxKzBPU3tKtFNing571/GwPBeCvmAUw0yBtfE2XVd0zFKJIMSWkHJcPQi0ekxjIts6L/rrZq5cxGQ==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
+            "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "7.0.1",
-                "@typescript-eslint/types": "7.0.1",
-                "@typescript-eslint/typescript-estree": "7.0.1",
-                "@typescript-eslint/visitor-keys": "7.0.1",
+                "@typescript-eslint/scope-manager": "7.4.0",
+                "@typescript-eslint/types": "7.4.0",
+                "@typescript-eslint/typescript-estree": "7.4.0",
+                "@typescript-eslint/visitor-keys": "7.4.0",
                 "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2944,15 +2942,15 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
-            "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
+            "integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
             "dependencies": {
-                "@typescript-eslint/types": "7.0.1",
-                "@typescript-eslint/visitor-keys": "7.0.1"
+                "@typescript-eslint/types": "7.4.0",
+                "@typescript-eslint/visitor-keys": "7.4.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2960,17 +2958,17 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.1.tgz",
-            "integrity": "sha512-YtT9UcstTG5Yqy4xtLiClm1ZpM/pWVGFnkAa90UfdkkZsR1eP2mR/1jbHeYp8Ay1l1JHPyGvoUYR6o3On5Nhmw==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz",
+            "integrity": "sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "7.0.1",
-                "@typescript-eslint/utils": "7.0.1",
+                "@typescript-eslint/typescript-estree": "7.4.0",
+                "@typescript-eslint/utils": "7.4.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2986,11 +2984,11 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
-            "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
+            "integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2998,12 +2996,12 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
-            "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
+            "integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
             "dependencies": {
-                "@typescript-eslint/types": "7.0.1",
-                "@typescript-eslint/visitor-keys": "7.0.1",
+                "@typescript-eslint/types": "7.4.0",
+                "@typescript-eslint/visitor-keys": "7.4.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -3012,7 +3010,7 @@
                 "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3025,20 +3023,20 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.1.tgz",
-            "integrity": "sha512-oe4his30JgPbnv+9Vef1h48jm0S6ft4mNwi9wj7bX10joGn07QRfqIqFHoMiajrtoU88cIhXf8ahwgrcbNLgPA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
+            "integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "7.0.1",
-                "@typescript-eslint/types": "7.0.1",
-                "@typescript-eslint/typescript-estree": "7.0.1",
+                "@typescript-eslint/scope-manager": "7.4.0",
+                "@typescript-eslint/types": "7.4.0",
+                "@typescript-eslint/typescript-estree": "7.4.0",
                 "semver": "^7.5.4"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3049,15 +3047,15 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
-            "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
+            "integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
             "dependencies": {
-                "@typescript-eslint/types": "7.0.1",
+                "@typescript-eslint/types": "7.4.0",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3774,9 +3772,9 @@
             "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
         },
         "node_modules/before-after-hook": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+            "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
             "dev": true
         },
         "node_modules/big.js": {
@@ -3796,12 +3794,12 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "dependencies": {
                 "bytes": "3.1.2",
-                "content-type": "~1.0.4",
+                "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
@@ -3809,7 +3807,7 @@
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
                 "qs": "6.11.0",
-                "raw-body": "2.5.1",
+                "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
             },
@@ -4584,9 +4582,9 @@
             "dev": true
         },
         "node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5116,12 +5114,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/deprecation": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-            "dev": true
         },
         "node_modules/destroy": {
             "version": "1.2.0",
@@ -5911,16 +5903,16 @@
             }
         },
         "node_modules/express": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+            "version": "4.19.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.1",
+                "body-parser": "1.20.2",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.5.0",
+                "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -6222,9 +6214,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.5",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "funding": [
                 {
                     "type": "individual",
@@ -7031,9 +7023,9 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-My1KCEPs6A0hb4qCVzYp8iEvA8j8YqcvXLZZH8C9OFuTYpYjHE7N2dtG3mRl1HMD4+VGXpF3XcDVcxGBT7yDZQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
@@ -7078,9 +7070,9 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.3.tgz",
-            "integrity": "sha512-kCnwztfX0KZJSLOBrcL0emLeFako55NWMovvyPP2AjsghNk9RB1yjSI+jVumPHYZsNXegNoqupSW9IY3afSH8w==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.0.2",
@@ -7704,9 +7696,9 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
         "node_modules/issue-parser": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
-            "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.0.tgz",
+            "integrity": "sha512-jgAw78HO3gs9UrKqJNQvfDj9Ouy8Mhu40fbEJ8yXff4MW8+/Fcn9iFjyWUQ6SKbX8ipPk3X5A3AyfYHRu6uVLw==",
             "dev": true,
             "dependencies": {
                 "lodash.capitalize": "^4.2.1",
@@ -7716,7 +7708,7 @@
                 "lodash.uniqby": "^4.7.0"
             },
             "engines": {
-                "node": ">=10.13"
+                "node": "^18.17 || >=20.6.1"
             }
         },
         "node_modules/iterator.prototype": {
@@ -8709,9 +8701,9 @@
             }
         },
         "node_modules/normalize-url": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-            "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+            "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
             "dev": true,
             "engines": {
                 "node": ">=14.16"
@@ -8721,9 +8713,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-10.4.0.tgz",
-            "integrity": "sha512-RS7Mx0OVfXlOcQLRePuDIYdFCVBPCNapWHplDK+mh7GDdP/Tvor4ocuybRRPSvfcRb2vjRJt1fHCqw3cr8qACQ==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-10.5.0.tgz",
+            "integrity": "sha512-Ejxwvfh9YnWVU2yA5FzoYLTW52vxHCz+MHrOFg9Cc8IFgF/6f5AGPAvb5WTay5DIUP1NIfN3VBZ0cLlGO0Ys+A==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -8806,7 +8798,7 @@
                 "@npmcli/package-json": "^5.0.0",
                 "@npmcli/promise-spawn": "^7.0.1",
                 "@npmcli/run-script": "^7.0.4",
-                "@sigstore/tuf": "^2.3.0",
+                "@sigstore/tuf": "^2.3.1",
                 "abbrev": "^2.0.0",
                 "archy": "~1.0.0",
                 "cacache": "^18.0.2",
@@ -8857,7 +8849,7 @@
                 "proc-log": "^3.0.0",
                 "qrcode-terminal": "^0.12.0",
                 "read": "^2.1.0",
-                "semver": "^7.5.4",
+                "semver": "^7.6.0",
                 "spdx-expression-parse": "^3.0.1",
                 "ssri": "^10.0.5",
                 "supports-color": "^9.4.0",
@@ -8988,7 +8980,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/agent": {
-            "version": "2.2.0",
+            "version": "2.2.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9004,7 +8996,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "7.3.1",
+            "version": "7.4.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9017,7 +9009,7 @@
                 "@npmcli/name-from-folder": "^2.0.0",
                 "@npmcli/node-gyp": "^3.0.0",
                 "@npmcli/package-json": "^5.0.0",
-                "@npmcli/query": "^3.0.1",
+                "@npmcli/query": "^3.1.0",
                 "@npmcli/run-script": "^7.0.2",
                 "bin-links": "^4.0.1",
                 "cacache": "^18.0.0",
@@ -9051,7 +9043,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "8.1.0",
+            "version": "8.2.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9222,7 +9214,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/query": {
-            "version": "3.0.1",
+            "version": "3.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9260,19 +9252,19 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/bundle": {
-            "version": "2.1.1",
+            "version": "2.2.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/protobuf-specs": "^0.2.1"
+                "@sigstore/protobuf-specs": "^0.3.0"
             },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
             }
         },
         "node_modules/npm/node_modules/@sigstore/core": {
-            "version": "0.2.0",
+            "version": "1.0.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -9281,7 +9273,7 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-            "version": "0.2.1",
+            "version": "0.3.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -9290,14 +9282,14 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/sign": {
-            "version": "2.2.1",
+            "version": "2.2.3",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/bundle": "^2.1.1",
-                "@sigstore/core": "^0.2.0",
-                "@sigstore/protobuf-specs": "^0.2.1",
+                "@sigstore/bundle": "^2.2.0",
+                "@sigstore/core": "^1.0.0",
+                "@sigstore/protobuf-specs": "^0.3.0",
                 "make-fetch-happen": "^13.0.0"
             },
             "engines": {
@@ -9305,12 +9297,12 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/tuf": {
-            "version": "2.3.0",
+            "version": "2.3.1",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/protobuf-specs": "^0.2.1",
+                "@sigstore/protobuf-specs": "^0.3.0",
                 "tuf-js": "^2.2.0"
             },
             "engines": {
@@ -9318,14 +9310,14 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/verify": {
-            "version": "0.1.0",
+            "version": "1.1.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/bundle": "^2.1.1",
-                "@sigstore/core": "^0.2.0",
-                "@sigstore/protobuf-specs": "^0.2.1"
+                "@sigstore/bundle": "^2.2.0",
+                "@sigstore/core": "^1.0.0",
+                "@sigstore/protobuf-specs": "^0.3.0"
             },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
@@ -9732,7 +9724,7 @@
             }
         },
         "node_modules/npm/node_modules/diff": {
-            "version": "5.1.0",
+            "version": "5.2.0",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -9883,7 +9875,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/hasown": {
-            "version": "2.0.0",
+            "version": "2.0.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9913,7 +9905,7 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/http-proxy-agent": {
-            "version": "7.0.0",
+            "version": "7.0.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9926,7 +9918,7 @@
             }
         },
         "node_modules/npm/node_modules/https-proxy-agent": {
-            "version": "7.0.2",
+            "version": "7.0.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10008,11 +10000,24 @@
                 "node": "^16.14.0 || >=18.0.0"
             }
         },
-        "node_modules/npm/node_modules/ip": {
-            "version": "2.0.0",
+        "node_modules/npm/node_modules/ip-address": {
+            "version": "9.0.5",
             "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/npm/node_modules/ip-address/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/npm/node_modules/ip-regex": {
             "version": "5.0.0",
@@ -10089,6 +10094,12 @@
                 "@pkgjs/parseargs": "^0.11.0"
             }
         },
+        "node_modules/npm/node_modules/jsbn": {
+            "version": "1.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
         "node_modules/npm/node_modules/json-parse-even-better-errors": {
             "version": "3.0.1",
             "dev": true,
@@ -10142,7 +10153,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "6.0.6",
+            "version": "6.0.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10162,7 +10173,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "7.0.7",
+            "version": "7.0.8",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10184,7 +10195,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "5.0.4",
+            "version": "5.0.5",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10222,7 +10233,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "6.0.6",
+            "version": "6.0.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10297,7 +10308,7 @@
             }
         },
         "node_modules/npm/node_modules/lru-cache": {
-            "version": "10.1.0",
+            "version": "10.2.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10959,7 +10970,7 @@
             "optional": true
         },
         "node_modules/npm/node_modules/semver": {
-            "version": "7.5.4",
+            "version": "7.6.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11025,17 +11036,17 @@
             }
         },
         "node_modules/npm/node_modules/sigstore": {
-            "version": "2.2.0",
+            "version": "2.2.2",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/bundle": "^2.1.1",
-                "@sigstore/core": "^0.2.0",
-                "@sigstore/protobuf-specs": "^0.2.1",
-                "@sigstore/sign": "^2.2.1",
-                "@sigstore/tuf": "^2.3.0",
-                "@sigstore/verify": "^0.1.0"
+                "@sigstore/bundle": "^2.2.0",
+                "@sigstore/core": "^1.0.0",
+                "@sigstore/protobuf-specs": "^0.3.0",
+                "@sigstore/sign": "^2.2.3",
+                "@sigstore/tuf": "^2.3.1",
+                "@sigstore/verify": "^1.1.0"
             },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
@@ -11052,16 +11063,16 @@
             }
         },
         "node_modules/npm/node_modules/socks": {
-            "version": "2.7.1",
+            "version": "2.8.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 16.0.0",
                 "npm": ">= 3.0.0"
             }
         },
@@ -11090,7 +11101,7 @@
             }
         },
         "node_modules/npm/node_modules/spdx-exceptions": {
-            "version": "2.3.0",
+            "version": "2.5.0",
             "dev": true,
             "inBundle": true,
             "license": "CC-BY-3.0"
@@ -11106,7 +11117,7 @@
             }
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
-            "version": "3.0.16",
+            "version": "3.0.17",
             "dev": true,
             "inBundle": true,
             "license": "CC0-1.0"
@@ -13019,9 +13030,9 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
@@ -13176,9 +13187,9 @@
             }
         },
         "node_modules/read-pkg-up/node_modules/type-fest": {
-            "version": "4.10.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.2.tgz",
-            "integrity": "sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
+            "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
             "dev": true,
             "engines": {
                 "node": ">=16"
@@ -13205,9 +13216,9 @@
             }
         },
         "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "4.10.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.2.tgz",
-            "integrity": "sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
+            "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
             "dev": true,
             "engines": {
                 "node": ">=16"
@@ -13581,16 +13592,16 @@
             }
         },
         "node_modules/semantic-release": {
-            "version": "23.0.2",
-            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.2.tgz",
-            "integrity": "sha512-OnVYJ6Xgzwe1x8MKswba7RU9+5djS1MWRTrTn5qsq3xZYpslroZkV9Pt0dA2YcIuieeuSZWJhn+yUWoBUHO5Fw==",
+            "version": "23.0.6",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.6.tgz",
+            "integrity": "sha512-/r62F4PNhJZhyZYMobcpcACGwpFNQyaVcSmqZQXG50GMbHSBVZQLCvwafqxO1lDQKVgmGmyCEtOVYzwvzvyhVw==",
             "dev": true,
             "dependencies": {
-                "@semantic-release/commit-analyzer": "^11.0.0",
+                "@semantic-release/commit-analyzer": "^12.0.0",
                 "@semantic-release/error": "^4.0.0",
-                "@semantic-release/github": "^9.0.0",
-                "@semantic-release/npm": "^11.0.0",
-                "@semantic-release/release-notes-generator": "^12.0.0",
+                "@semantic-release/github": "^10.0.0",
+                "@semantic-release/npm": "^12.0.0",
+                "@semantic-release/release-notes-generator": "^13.0.0",
                 "aggregate-error": "^5.0.0",
                 "cosmiconfig": "^9.0.0",
                 "debug": "^4.0.0",
@@ -15053,9 +15064,9 @@
             }
         },
         "node_modules/universal-user-agent": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
             "dev": true
         },
         "node_modules/universalify": {
@@ -15288,9 +15299,9 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-            "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
             "dependencies": {
                 "colorette": "^2.0.10",
                 "memfs": "^3.4.3",
@@ -15359,9 +15370,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.15.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
-            "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+            "version": "4.15.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
+            "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
                 "@types/connect-history-api-fallback": "^1.3.5",
@@ -15391,7 +15402,7 @@
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.1",
+                "webpack-dev-middleware": "^5.3.4",
                 "ws": "^8.13.0"
             },
             "bin": {

--- a/package.json
+++ b/package.json
@@ -35,12 +35,11 @@
         "prettier": "prettier --write \"**/*.json\" \"**/*.js\""
     },
     "dependenciesComments": {
-        "fork-ts-checker-webpack-plugin": "Support for eslint was removed in 7.x. We need to stay on 6.x until we find a replacement strategy for linting.",
-        "semantic-release": "v20.0 onwards requires Node 18."
+        "fork-ts-checker-webpack-plugin": "Support for eslint was removed in 7.x. We need to stay on 6.x until we find a replacement strategy for linting."
     },
     "dependencies": {
-        "@typescript-eslint/eslint-plugin": "~7.0.1",
-        "@typescript-eslint/parser": "~7.0.1",
+        "@typescript-eslint/eslint-plugin": "~7.4.0",
+        "@typescript-eslint/parser": "~7.4.0",
         "chalk": "~5.3.0",
         "clean-webpack-plugin": "~4.0.0",
         "css-loader": "~6.10.0",
@@ -72,7 +71,7 @@
         "p-retry": "6.2.0",
         "playwright-chromium": "1.41.2",
         "prettier": "3.2.5",
-        "semantic-release": "23.0.2",
+        "semantic-release": "23.0.6",
         "simple-git-hooks": "2.9.0",
         "typescript": "5.3.3"
     },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -61,7 +61,7 @@ const build = () => {
                 );
                 console.log(
                     `You can learn more about deploying your custom code at ${chalk.cyan(
-                        "https://developers.vertigis.com/docs/web/overview/"
+                        "https://developers.vertigisstudio.com/docs/web/overview/"
                     )}`
                 );
             }

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -145,7 +145,7 @@ const printSuccess = () => {
     console.log(chalk.cyan(`  cd ${directoryName}`));
     console.log(chalk.cyan("  npm start\n"));
     console.log(
-        "You can learn more by visiting https://developers.vertigis.com/docs/web/sdk-overview/"
+        "You can learn more by visiting https://developers.vertigisstudio.com/docs/web/sdk-overview/"
     );
 };
 

--- a/template/package.json
+++ b/template/package.json
@@ -13,6 +13,6 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "typescript": "^4.8.4"
+        "typescript": "^5.3.3"
     }
 }

--- a/template/src/components/PointsOfInterest/PointOfInterest.tsx
+++ b/template/src/components/PointsOfInterest/PointOfInterest.tsx
@@ -1,6 +1,7 @@
 import { xyToLngLat } from "@arcgis/core/geometry/support/webMercatorUtils";
 import { format as formatNumber } from "@vertigis/arcgis-extensions/utilities/number";
 import { useWatchAndRerender } from "@vertigis/web/ui";
+import Box from "@vertigis/web/ui/Box";
 import DynamicIcon from "@vertigis/web/ui/DynamicIcon";
 import IconButton from "@vertigis/web/ui/IconButton";
 import ListItemText from "@vertigis/web/ui/ListItemText";
@@ -35,7 +36,7 @@ const PointOfInterest: FC<PointOfInterestProps> = ({
     const [lon, lat] = xyToLngLat(geometry.x, geometry.y);
     return (
         <MenuItem {...other}>
-            <div
+            <Box
                 className="PointOfInterest-swatch"
                 style={{ backgroundColor: color.toCss() }}
             />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,21 @@
     "compilerOptions": {
         "allowJs": true,
         "esModuleInterop": true,
+        "jsx": "react",
         "module": "ESNext",
         "moduleResolution": "node",
         "outDir": "bogus",
         "target": "ESNext"
     },
-    "include": [".eslintrc.cjs", "bin", "config", "lib", "scripts", "test"]
+    "include": [
+        ".eslintrc.cjs",
+        "bin",
+        "config",
+        "lib",
+        "scripts",
+        "test",
+        "template/src/*.ts",
+        "template/src/**/**/*.ts",
+        "template/src/**/**/*.tsx"
+    ]
 }


### PR DESCRIPTION
- Fixed the broken help urls in the `create` and `build` scripts.
- Updated a couple of packages to remove warnings.
- Updated typescript in the sample template.
- Changed a `div` to a `Box` in the sample template.
- Fixed linter not running on sample template.