### PR TITLE
fix: remove new tsconfig rules that throw errors

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -14,8 +14,6 @@
         "moduleResolution": "node",
         "noEmit": true,
         "noImplicitAny": false,
-        "noImplicitOverride": true,
-        "noImplicitReturns": true,
         "paths": {
             "esri/*": ["./node_modules/@arcgis/core/*"]
         },


### PR DESCRIPTION
These shouldn't have been added as they are a potential breaking change for existing code.