### PR TITLE
Mark only specific VertiGIS packages as external

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -48,7 +48,10 @@ export default {
     externals: [
         /^@arcgis\/core\/.+$/,
         /^esri\/.+$/,
-        /^@vertigis\/.+$/,
+        /^@vertigis\/arcgis-extensions\/.+$/,
+        /^@vertigis\/viewer-spec\/.+$/,
+        /^@vertigis\/web\/.+$/,
+        /^@vertigis\/workflow\/.+$/,
         /^react(\/.+)*$/,
         /^react-dom(\/.+)*$/,
     ],


### PR DESCRIPTION
Web can no longer handle requests for `@vertigis/arcgis-rest-client`