### PR TITLE
fix: update links in README for VertiGIS Studio Developer Center documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Builds the library for production to the `build` folder. It optimizes the build 
 
 Your custom library is now ready to be deployed!
 
-See the [section about deployment](https://developers.vertigis.com/docs/web/sdk-deployment/) in the [Developer Center](https://developers.vertigis.com/docs/web/overview/) for more information.
+See the [section about deployment](https://developers.vertigisstudio.com/docs/web/sdk-deployment/) in the [Developer Center](https://developers.vertigisstudio.com/docs/web/overview/) for more information.
 
 ## Documentation
 
-Find [further documentation on the SDK](https://developers.vertigis.com/docs/web/sdk-overview/) on the [VertiGIS Studio Developer Center](https://developers.vertigis.com/docs/web/overview/)
+Find [further documentation on the SDK](https://developers.vertigisstudio.com/docs/web/sdk-overview/) on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/web/overview/)
 
 ## Contributing
 


### PR DESCRIPTION
fix: update documentation URLs to use correct domain

Several documentation links were pointing to the an incorrect domain (developers.vertigis.com). 
Updated these to use the current domain (developers.vertigisstudio.com) to ensure users 
can access the correct documentation resources.

Changes:
- Updated deployment guide link
- Updated Developer Center links
- Updated SDK documentation link